### PR TITLE
Added a setting to disable the integration between Hubitat and Homebr…

### DIFF
--- a/smartapps/tonesto7/homebridge-hubitat.src/homebridge-hubitat.groovy
+++ b/smartapps/tonesto7/homebridge-hubitat.src/homebridge-hubitat.groovy
@@ -120,6 +120,9 @@ def mainPage() {
                     input "sensorAllowTemp", "capability.sensor", title: inputTitleStr("Allow Temp on these Sensors"), multiple: true, submitOnChange: true, required: false
                 }
             }
+			section(sectionTitleStr("Disable HomeBridge-Hubitat integration?")) {
+				input "disableHomeBridge", "bool", title: "Disable HomeBridge-Hubitat integration?", required: true, defaultValue: false
+			}
             section("</br>${sectionTitleStr("Create Mode Devices in HomeKit?")}") {
                 paragraph '<small style="color: blue !important;"><i><b>Description:</b></small><br/><small style="color: grey !important;">A virtual switch will be created for each mode in HomeKit.</br>The switch will be ON when that mode is active.</i></small>', state: "complete"
                 def modes = location?.modes?.sort{it?.name}?.collect { [(it?.id):it?.name] }
@@ -431,6 +434,11 @@ def CommandReply(statusOut, messageOut) {
 }
 
 def lanEventHandler(evt) {
+	
+	if (disableHomeBridge) {
+		return
+	}
+	
     // log.trace "lanStreamEvtHandler..."
     def msg = parseLanMessage(evt?.description)
     Map headerMap = msg?.headers
@@ -715,6 +723,10 @@ def changeHandler(evt) {
     def value = evt?.value
     def dt = evt?.date
     def sendEvt = true
+	
+	if (disableHomeBridge) {
+		return
+	}
 
     switch(evt?.name) {
         case "hsmStatus":


### PR DESCRIPTION
…idge.

This is a better way to turn off the integration than powering down the Homebridge server.  My specific use case is for when I am developing/debugging code having to do with the smart door locks.  While I'm testing, I don't want constant HomeKit notifications being sent to the other household members.  This lets me easily turn off the integration so I can debug without disturbing anyone.