### PR TITLE
Added negative temperature support (Celsius scale)

### DIFF
--- a/accessories/he_st_accessories.js
+++ b/accessories/he_st_accessories.js
@@ -610,7 +610,7 @@ function HE_ST_Accessory(platform, device) {
             if (that.deviceGroup === 'unknown') {
                 that.deviceGroup = 'sensor';
             }
-            thisCharacteristic = that.getaddService(Service.TemperatureSensor).getCharacteristic(Characteristic.CurrentTemperature)
+            thisCharacteristic = that.getaddService(Service.TemperatureSensor).getCharacteristic(Characteristic.CurrentTemperature).setProps({minValue: -100})
                 .on('get', function(callback) {
                     if (platform.temperature_unit === 'C') {
                         callback(null, Math.round(that.device.attributes.temperature * 10) / 10);
@@ -767,7 +767,7 @@ function HE_ST_Accessory(platform, device) {
                     });
                 platform.addAttributeUsage('humidity', device.deviceid, thisCharacteristic);
             }
-            thisCharacteristic = that.getaddService(Service.Thermostat).getCharacteristic(Characteristic.CurrentTemperature)
+            thisCharacteristic = that.getaddService(Service.Thermostat).getCharacteristic(Characteristic.CurrentTemperature).setProps({minValue: -100})
                 .on('get', function(callback) {
                     if (platform.temperature_unit === 'C') {
                         callback(null, Math.round(that.device.attributes.temperature * 10) / 10);
@@ -776,7 +776,7 @@ function HE_ST_Accessory(platform, device) {
                     }
                 });
             platform.addAttributeUsage('temperature', device.deviceid, thisCharacteristic);
-            thisCharacteristic = that.getaddService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature)
+            thisCharacteristic = that.getaddService(Service.Thermostat).getCharacteristic(Characteristic.TargetTemperature).setProps({minValue: -100})
                 .on('get', function(callback) {
                     var temp;
                     switch (that.device.attributes.thermostatMode) {
@@ -850,7 +850,7 @@ function HE_ST_Accessory(platform, device) {
             platform.addAttributeUsage('coolingSetpoint', device.deviceid, thisCharacteristic);
             platform.addAttributeUsage('heatingSetpoint', device.deviceid, thisCharacteristic);
             platform.addAttributeUsage('temperature', device.deviceid, thisCharacteristic);
-            thisCharacteristic = that.getaddService(Service.Thermostat).getCharacteristic(Characteristic.TemperatureDisplayUnits)
+            thisCharacteristic = that.getaddService(Service.Thermostat).getCharacteristic(Characteristic.TemperatureDisplayUnits).setProps({minValue: -100})
                 .on('get', function(callback) {
                     if (platform.temperature_unit === 'C') {
                         callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);


### PR DESCRIPTION
Fixed issue when temperature sensor in IOS would say not responding if temperature value was negative.


![image](https://user-images.githubusercontent.com/20760161/97064277-fa488600-1561-11eb-80e5-f6ac3ba1c941.png)

![image](https://user-images.githubusercontent.com/20760161/97064287-07fe0b80-1562-11eb-9994-addb98a63721.png)


Signed-off-by: RamSet <RamSet@gmail.com>