### PR TITLE
Remove function code from debug log messages

### DIFF
--- a/src/HE_Accessories.js
+++ b/src/HE_Accessories.js
@@ -209,15 +209,15 @@ module.exports = class ST_Accessories {
     }
 
     log_change(attr, char, acc, chgObj) {
-        if (this.logConfig.debug === true) this.log.notice(`[CHARACTERISTIC (${char}) CHANGE] ${attr} (${acc.displayName}) | LastUpdate: (${acc.context.lastUpdate}) | NewValue: (${chgObj.newValue}) | OldValue: (${chgObj.oldValue})`);
+        if (this.logConfig.debug === true) this.log.notice(`[CHARACTERISTIC (${char.name}) CHANGE] ${attr} (${acc.displayName}) | LastUpdate: (${acc.context.lastUpdate}) | NewValue: (${chgObj.newValue}) | OldValue: (${chgObj.oldValue})`);
     }
 
     log_get(attr, char, acc, val) {
-        if (this.logConfig.debug === true) this.log.good(`[CHARACTERISTIC (${char}) GET] ${attr} (${acc.displayName}) | LastUpdate: (${acc.context.lastUpdate}) | Value: (${val})`);
+        if (this.logConfig.debug === true) this.log.good(`[CHARACTERISTIC (${char.name}) GET] ${attr} (${acc.displayName}) | LastUpdate: (${acc.context.lastUpdate}) | Value: (${val})`);
     }
 
     log_set(attr, char, acc, val) {
-        if (this.logConfig.debug === true) this.log.warn(`[CHARACTERISTIC (${char}) SET] ${attr} (${acc.displayName}) | LastUpdate: (${acc.context.lastUpdate}) | Value: (${val})`);
+        if (this.logConfig.debug === true) this.log.warn(`[CHARACTERISTIC (${char.name}) SET] ${attr} (${acc.displayName}) | LastUpdate: (${acc.context.lastUpdate}) | Value: (${val})`);
     }
 
     hasCapability(obj) {


### PR DESCRIPTION
This change shows the characteristic name in the logs, rather than its entire code block

## Checklist:

-   [X ] My code follows the code style of this project.
-   [/] My change requires a change to the documentation.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description of Changes

Changes this log line:
```
[11/7/2020, 4:40:51 am] [GOOD]: [CHARACTERISTIC (function Saturation() {
        var _this = _super.call(this, 'Saturation', Saturation.UUID) || this;
        _this.setProps({
            format: "float" /* FLOAT */,
            unit: "percentage" /* PERCENTAGE */,
            maxValue: 100,
            minValue: 0,
            minStep: 1,
            perms: ["pr" /* READ */, "pw" /* WRITE */, "ev" /* NOTIFY */]
        });
        _this.value = _this.getDefaultValue();
        return _this;
    }) GET] saturation (Gardenspots) | LastUpdate: (Sat Nov 07 2020 04:40:51 GMT-0800 (Pacific Standard Time)) | Value: (97)
```

...to this:
```
[11/7/2020, 12:50:54 pm] [Hubitat-v2] GOOD: [CHARACTERISTIC (Saturation) GET] saturation (Gardenspots) | LastUpdate: (Sat Nov 07 2020 12:50:54 GMT-0800 (Pacific Standard Time)) | Value: (97)
```

## Reason for Change

I don't see any value in showing the code implementation of the function in the logs.

## How Has This Been Tested?

Edited in place on my Homebridge, observed both log improvements and no stacktraces or other errors

## Screenshots (if appropriate):

<img width="1033" alt="Screen Shot 2020-11-07 at 1 11 04 PM" src="https://user-images.githubusercontent.com/1417194/98451487-c2f9dd80-20fa-11eb-9c03-5e40a859e804.png">
