### PR TITLE
Improve debug logging for API failures

### DIFF
--- a/src/HE_Client.js
+++ b/src/HE_Client.js
@@ -6,6 +6,7 @@ module.exports = class ST_Client {
     constructor(platform) {
         this.platform = platform;
         this.log = platform.log;
+        this.logConfig = platform.logConfig;
         this.appEvts = platform.appEvts;
         this.use_cloud = platform.use_cloud;
         this.hubIp = platform.local_hub_ip;
@@ -70,9 +71,12 @@ module.exports = class ST_Client {
                     this.log.error(`${src} Error | Possible Internet/Network/DNS Error | Unable to reach the uri | Message ${err.message}`);
                 } else {
                     // console.error(err);
-                    this.log.error(`${src} Error: ${err.response} | Message: ${err.message}`);
+                    this.log.error(`${src} ${err.response.defined ? err.response : 'Connection failure'} | Message: ${err.message}`);
                 }
                 break;
+        }
+        if (this.logConfig.debug === true) {
+            this.log.debug(`${src} ${JSON.stringify(err)}`);
         }
     }
 


### PR DESCRIPTION
## Description of Changes

Replace an undefined err.response object with a useful string
Add full stringify of the error object when debugging enabled

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reason for Change

* Hard to debug failed communications without it
* `err.response` not existing on connection failures creates logs with uninformative `[Object object]`

## How Has This Been Tested?

On my homebridge instance

## Screenshots (if appropriate):

<img width="1552" alt="Screen Shot 2020-11-07 at 4 42 46 PM" src="https://user-images.githubusercontent.com/1417194/98454359-86d57580-2118-11eb-852d-f5c01a9ab1f5.png">
